### PR TITLE
Travis: cache pip installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@ sudo: false
 language: python
 python:
   - 2.7
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - docs/_build
 install:
+  - pip install --upgrade pip
   - pip install -r requirements/test.txt
   - pip install .
 script:


### PR DESCRIPTION
Cache pip downloads and use newer pip to save the wheels.  Which should
mean lxml is compiled only once and then a cached compile is used on
subsequent runs.
